### PR TITLE
build: depend on golang 1.18

### DIFF
--- a/spicetify-cli.rb
+++ b/spicetify-cli.rb
@@ -7,7 +7,7 @@ class SpicetifyCli < Formula
   head "https://github.com/spicetify/spicetify-cli"
   sha256 "f42f92e67634f14eda3bbab61478c851f2b6a6539953b2dfbe1b7478d4d40cfd"
 
-  depends_on "go" => :build
+  depends_on "go" => "1.18"
 
   def install
     ENV["GOPATH"] = buildpath


### PR DESCRIPTION
As we seen before (https://github.com/khanhas/homebrew-tap/issues/12), depending on building latest golang version isn't ideal and we should lock golang version to 1.18 (latest release), so it will not break with newer golang versions.